### PR TITLE
Stylistic improvements

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -38,7 +38,7 @@ async function createData() {
 
 async function getData() {
   if (iteration > 100) {
-    console.log("- - - - Done - - - -")
+    console.log("- - - - Done - - - -");
     console.log("Total time", totalTime);
     console.log("Average request time", totalTime / iteration);
     cacheStatus.ttl.time = cacheStatus.ttl.time / cacheStatus.ttl.count;
@@ -71,7 +71,7 @@ async function getData() {
 
 async function main() {
   getData();
-  // createData()
+  // createData();
 }
 
 main()

--- a/index.ts
+++ b/index.ts
@@ -74,12 +74,7 @@ async function main() {
   // createData();
 }
 
-main()
-  .then(async () => {
-    await prisma.$disconnect();
-  })
-  .catch(async (e) => {
-    console.error(e);
-    await prisma.$disconnect();
-    process.exit(1);
-  });
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/index.ts
+++ b/index.ts
@@ -24,15 +24,11 @@ let cacheStatus = {
 };
 
 async function createData() {
-  await prisma.user.create({
-    data: {
-      email: "loelhoeffel5@prisma.io",
-    },
-  });
-  await prisma.user.create({
-    data: {
-      email: "loelhoeffel6@prisma.io",
-    },
+  const lastCount = await prisma.user.count();
+  await prisma.user.createMany({
+    data: Array.from({ length: 10 }).map((_, index) => ({
+      email: `user${lastCount + index}@prisma.io`,
+    })),
   });
 }
 
@@ -70,8 +66,11 @@ async function getData() {
 }
 
 async function main() {
-  getData();
-  // createData();
+  if (process.argv[2] === "seed") {
+    await createData();
+  } else {
+    await getData();
+  }
 }
 
 main().catch((e) => {

--- a/index.ts
+++ b/index.ts
@@ -56,14 +56,16 @@ async function getData() {
     }
   }
 
-  console.log("- - - - Done - - - -");
+  console.log("\n- - - - Done - - - -");
   console.log("Total time", totalTime);
   console.log("Average request time", totalTime / requestsCount);
+
   cacheStatus.ttl.time = cacheStatus.ttl.time / cacheStatus.ttl.count;
   cacheStatus.swr.time = cacheStatus.swr.time / cacheStatus.swr.count;
   cacheStatus.miss.time = cacheStatus.miss.time / cacheStatus.miss.count;
   cacheStatus.none.time = cacheStatus.none.time / cacheStatus.none.count;
   console.log(cacheStatus);
+
   return;
 }
 

--- a/index.ts
+++ b/index.ts
@@ -65,8 +65,6 @@ async function getData() {
   cacheStatus.miss.time = cacheStatus.miss.time / cacheStatus.miss.count;
   cacheStatus.none.time = cacheStatus.none.time / cacheStatus.none.count;
   console.log(cacheStatus);
-
-  return;
 }
 
 async function main() {


### PR DESCRIPTION
- Don't use `prisma.$disconnect` as it's a no-op and doesn't do anything in the client generated for Data Proxy and Accelerate (and not that useful in this case with library engine either, it would only be necessary with the binary engine here). Also that `$disconnect` used to run before the queries due to a missing `await` in the `main` function, which is now fixed too.
- Create new records via CLI arg (`ts-node index.ts seed`) rather than commenting/uncommenting code, give them unique-ish names.
- Rewrite `getData` to a loop, make variables local and the control flow more straightforward.